### PR TITLE
Fixed readme to reflect new examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To simulate a Linguine-compiled shader on your browser:
 
 For example:
 
-    $ make run src=lighting
+    $ make run src=phong
 
 You can run the compiler by passing the `*.lgl` source file as an argument to `lingc`.
 For example:


### PR DESCRIPTION
The current README uses `make run src=lighting` as an example, which no longer works as lighting isn't an example.

This confused me for a bit, since it doesn't throw any kind of error, it's just not possible to access the localhost page.

This changes it to be `make run src=phong`.