### PR TITLE
Construct buffer for normals from .obj files

### DIFF
--- a/examples/lglexample.ts
+++ b/examples/lglexample.ts
@@ -280,7 +280,8 @@ export function load_obj (gl: WebGLRenderingContext, obj_src: string): Mesh {
   // .obj files can have normals, but if they don't, this parser library
   // (confusingly) fills the array with NaN.
   if (!isNaN(mesh.vertexNormals[0])) {
-    out.normals = group_array(mesh.vertexNormals, 3) as Vec3Array;
+    let normals = group_array(mesh.vertexNormals, 3) as Vec3Array;
+    out.normals = make_buffer(gl, normals, 'float32', gl.ARRAY_BUFFER);
   }
 
   return out;


### PR DESCRIPTION
This path, where the .obj parser produces a normals array, was filling in `out.normals` with a plain JavaScript array instead of a WebGL buffer. Now it gets a proper buffer.