### PR TITLE
Revamp TOST computation

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -4,3 +4,4 @@ pandas
 matplotlib
 numpy
 scipy
+statsmodels

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -22,7 +22,7 @@ df = pd.DataFrame([(d, *(tup[1:])) for tup in df1.itertuples()
                    for d in tup.fpsData])
 df.columns = ['frame'] + list(df1.columns)
 bench_names = list(set(list(df['bench_name'])))
-for bench in bench_names:
+for bench in sorted(bench_names):
     data_raw = df.loc[(df['shader'] == 'raw') & (
         df['bench_name'] == bench)]['frame']
     data_default = df.loc[(df['shader'] ==
@@ -58,8 +58,8 @@ for bench in bench_names:
 
     # Now, if we have *rejected* both of the null hypotheses, we know
     # that the difference is smaller than DELTA in both directions.
-    p_tost = max(p_left, p_right)
-    print(f" TOST p: {p_tost:.2f} " +
+    p_tost = max(p_left, p_right)  # Take the *worst* p-value.
+    print(f" TOST p: {p_tost:.3f} " +
           ("*" if p_tost < ALPHA else ""))
 
     print('---------')

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -11,6 +11,7 @@ import os.path
 import statsmodels.stats.weightstats as sm
 
 DELTA = 1.0  # Tolerance for the TOST.
+ALPHA = 0.01  # p-value threshold.
 FILE_NAME = 'data/run.json'
 if len(sys.argv) > 1:
     FILE_NAME = sys.argv[1]
@@ -53,10 +54,13 @@ for bench in bench_names:
         alternative='smaller',
         value=DELTA,
     )[1]
-    print(f" TOST p: smaller {p_left:.1e} larger {p_right:.1e}")
+    print(f" TOST  : smaller {p_left:.3f} larger {p_right:.3f}")
 
     # Now, if we have *rejected* both of the null hypotheses, we know
     # that the difference is smaller than DELTA in both directions.
+    p_tost = max(p_left, p_right)
+    print(f" TOST p: {p_tost:.2f} " +
+          ("*" if p_tost < ALPHA else ""))
 
     print('---------')
 

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -32,15 +32,13 @@ for bench in bench_names:
     print(f"Means \n GLSL: {np.mean(data_raw)} Gator: {np.mean(data_default)}")
     print(f" Ttest : {scipy.stats.ttest_ind(data_raw, data_default).pvalue}")
     print(f" Wilcox: {scipy.stats.wilcoxon(data_raw, data_default).pvalue}")
-    print(np.mean(diff))
-    print(np.std(diff))
+    print(f" diff  : mean {np.mean(diff):.2f}, std {np.std(diff):.2f} "
+          f" stderr {scipy.stats.sem(diff):.2f}")
     low = -.1
     upp = .1
     pv1 = scipy.stats.ttest_1samp(diff, low).pvalue
     pv2 = scipy.stats.ttest_1samp(diff, upp).pvalue
-    print(pv1)
-    print(pv2)
-    print(f" TOST  : {max(pv1,pv2) / 2.}")
+    print(f" TOST  : {max(pv1,pv2) / 2.:.2f} (pv1={pv1:.2f}, pv2={pv2:.2f})")
     print('---------')
 
 # PLOT_TYPE = "bar"

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -34,8 +34,14 @@ for bench in sorted(bench_names):
           f"GLSL {np.mean(data_raw):.2f} ± {sem(data_raw):.2f}  "
           f"Gator {np.mean(data_default):.2f} ± {sem(data_default):.2f}")
     print(f" Diff  : {np.mean(data_raw) - np.mean(data_default) : .2f}")
-    print(f" Ttest : {scipy.stats.ttest_ind(data_raw, data_default).pvalue}")
-    print(f" Wilcox: {scipy.stats.wilcoxon(data_raw, data_default).pvalue}")
+
+    # Difference of means tests.
+    p_t = scipy.stats.ttest_ind(data_raw, data_default).pvalue
+    p_wilcoxon = scipy.stats.wilcoxon(data_raw, data_default).pvalue
+    print(f" Ttest : {p_t:.3f} " +
+          ("*" if p_t < ALPHA else ""))
+    print(f" Wilcox: {p_wilcoxon:.3f} " +
+          ("*" if p_wilcoxon < ALPHA else ""))
 
     # TOST! We first perform two one-tailed t-tests where the null
     # hypothesis H0 is that the difference of means is *large* (so the

--- a/benchmarks/visualize.py
+++ b/benchmarks/visualize.py
@@ -11,7 +11,7 @@ import os.path
 import statsmodels.stats.weightstats as sm
 
 DELTA = 1.0  # Tolerance for the TOST.
-ALPHA = 0.01  # p-value threshold.
+ALPHA = 0.05  # p-value threshold.
 FILE_NAME = 'data/run.json'
 if len(sys.argv) > 1:
     FILE_NAME = sys.argv[1]


### PR DESCRIPTION
This is for our new ["two one-sided tests" equivalence check procedure][tost]. It uses t-tests for now; it may be possible to adapt to Wilcoxon tests.

Looks like SciPy itself doesn't have a one-tailed t-test implementation with a "difference threshold" value, so I turned to a different library called [statsmodels][]. I tried to comment heavily to explain my reasoning behind the two tests.

Here's what the output currently looks like for the data set I currently have:

```
phong
Means  : GLSL 207.32 ± 0.09  Gator 207.09 ± 0.10
 Diff  :  0.23
 Ttest : 0.088 
 Wilcox: 0.097 
 TOST  : smaller 0.000 larger 0.000
 TOST p: 0.000 *
---------
reflection
Means  : GLSL 225.66 ± 0.11  Gator 225.91 ± 0.11
 Diff  : -0.25
 Ttest : 0.109 
 Wilcox: 0.204 
 TOST  : smaller 0.000 larger 0.000
 TOST p: 0.000 *
---------
shadow_map
Means  : GLSL 609.83 ± 0.61  Gator 616.30 ± 0.66
 Diff  : -6.46
 Ttest : 0.000 *
 Wilcox: 0.000 *
 TOST  : smaller 1.000 larger 0.000
 TOST p: 1.000 
---------
texture
Means  : GLSL 88.51 ± 0.27  Gator 88.69 ± 0.27
 Diff  : -0.18
 Ttest : 0.646 
 Wilcox: 0.563 
 TOST  : smaller 0.016 larger 0.001
 TOST p: 0.016 *
---------
```

A few things to note here:

- I'm printing out the mean difference in frame rate to help guide intuition. It helps show, for example, that there is actually a nontrivial difference for `shadow_map`.
- The test I'm currently running checks whether there is a greater than 1.0 difference between the two means (i.e., H0 is that they differ by one fps).
- The asterisk next to the TOST p-value indicates statistical significance. I applied a p-value threshold of α=0.05. In this setup, the test succeeds for everything but `shadow_map`, where the fps difference is obviously bigger than 1.

[statsmodels]: https://www.statsmodels.org/
[tost]: https://en.wikipedia.org/wiki/Equivalence_test